### PR TITLE
Add last updated time to the popup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Trillium Tap List",
   "description": "Lets Chrome users know 'whats on tap' at Trillium at all times",
-  "version": "1.1.1",
+  "version": "1.1.2",
 
   "browser_action": {
     "default_icon":  "icon.png",

--- a/popup.html
+++ b/popup.html
@@ -50,6 +50,8 @@
 <label for="bottles">Current Bottles</label><div id="bottles">Loading...</div>
 <label for="up-next" id="up-next-label">Up Next</label><div id="up-next">Loading...</div>
 <label for="hours">Hours</label><div id="hours">Loading...</div>
+<label for="lastUpdated">Last Updated</label><div id="last-updated">Loading...</div>
+
 <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -11,20 +11,24 @@ xhr.onload = function() {
         growlersDiv      = document.getElementById('growlers'),
         bottlesDiv       = document.getElementById('bottles'),
         upNextDiv        = document.getElementById('up-next'),
+        lastUpdatedDiv   = document.getElementById('last-updated'),
         retailHoursStart = this.responseText.indexOf('Retail Hours'),
         growlersStart    = this.responseText.indexOf('Growler Fills'),
         bottlesStart     = this.responseText.indexOf('Bottles'),
         upNextStart      = this.responseText.indexOf('Up Next'),
         bottleShopsStart = this.responseText.indexOf('BOTTLE SHOPS'),
+        lastUpdatedStart = this.responseText.indexOf('UPDATED'),
         retailHours,
         growlers,
         bottles,
-        upNext;
+        upNext,
+        lastUpdated;
 
     retailHours = this.responseText.substring(retailHoursStart, growlersStart).match(/<h3>(.*?)<\/h3>/ig);
     growlers    = this.responseText.substring(growlersStart, bottlesStart).match(/<h3>(.*?)<\/h3>/ig);
     bottles     = this.responseText.substring(bottlesStart, upNextStart).match(/<h3>(.*?)<\/h3>/ig);
     upNext      = this.responseText.substring(upNextStart, bottleShopsStart).match(/<h3>(.*?)<\/h3>/ig);
+    lastUpdated = this.responseText.substring(lastUpdatedStart + 8, lastUpdatedStart + 40).split('</span>')[0];
 
     hoursDiv.innerHTML = '';
     retailHours.forEach(function(r) {
@@ -40,6 +44,9 @@ xhr.onload = function() {
     bottles.forEach(function(r) {
         bottlesDiv.innerHTML = bottlesDiv.innerHTML + r;
     });
+
+    lastUpdatedDiv.innerHTML = '<h3>' + lastUpdated + '</h3';
+
 
     if (localStorage['showUpcoming'] *1) {
         upNextDiv.innerHTML = '';


### PR DESCRIPTION
Hey I added last updated time at the bottom. I usually take a look at that when I look at the trillium page as well. 

There wasn't a very clean way to grab the time that I could see, but this works.
